### PR TITLE
Only include arguments when needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,18 @@ runs:
         AWS_ACCESS_KEY_ID="${{inputs.access_key_id}}" \
         AWS_SECRET_ACCESS_KEY="${{inputs.secret_access_key}}" \
           aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin ${{inputs.ecr_uri}}
-        [ -z "${{inputs.github_ssh_key}}" ] \
-          && docker build -t $CONTAINER_IMAGE_SHA -t $CONTAINER_IMAGE_LATEST --build-arg "GITHUB_SHA=${{github.sha}}" . \
-          || docker build -t $CONTAINER_IMAGE_SHA -t $CONTAINER_IMAGE_LATEST --build-arg "GITHUB_SHA=${{github.sha}}" --build-arg "GITHUB_SSH_KEY=${{inputs.github_ssh_key}}".
+        # Only include the GITHUB_SSH_KEY if it exists
+        [ -n "${{inputs.github_ssh_key}}" ] && ARG_GITHUB_SSH_KEY='--build-arg "GITHUB_SSH_KEY=${{inputs.github_ssh_key}}"'
+        # Only include the GITHUB_SHA if it is used (supresses a warning)
+        grep -q "GITHUB_SHA" ./Dockerfile > /dev/null && ARG_GITHUB_SHA='--build-arg "GITHUB_SHA=${{github.sha}}"'
+
+        eval docker build \
+          -t $CONTAINER_IMAGE_SHA \
+          -t $CONTAINER_IMAGE_LATEST \
+          $ARG_GITHUB_SSH_KEY \
+          $ARG_GITHUB_SHA \
+          . 
+
         [ "${{inputs.deploy}}" = "true" ] \
           && docker push $CONTAINER_IMAGE_SHA \
           && docker push $CONTAINER_IMAGE_LATEST


### PR DESCRIPTION
- During docker build, suppress warnings if the build-args aren't needed

Tested here:  https://github.com/glg/bad-service/runs/1243848513?check_suite_focus=true

![image](https://user-images.githubusercontent.com/7997948/95780694-f713e700-0c91-11eb-946a-76b824a166b5.png)

Suppressed here: https://github.com/glg/bad-service/runs/1243779529?check_suite_focus=true

![image](https://user-images.githubusercontent.com/7997948/95780799-2de9fd00-0c92-11eb-98ad-aaa928d216c0.png)

See build logs for the lack of warning at the above link.

