### PR TITLE
Healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # build-and-deploy-ecr
-This github action builds a docker image from a dockerfile, and pushes it to ECR in compliance with GLG naming conventions
+This github action builds a docker image from a dockerfile, healthchecks it, and pushes it to ECR in compliance with GLG naming conventions
 
 ## Requirements
 
@@ -11,6 +11,18 @@ This action requires certain things to be configured in your repo:
     2. `ECR_AWS_ACCESS_KEY_ID`
     3. `ECR_AWS_SECRET_ACCESS_KEY`
 3. This action was developed against the `ubuntu-20.04` github actions environment, and it may not work correctly in a different environment.
+
+## Configuration
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |
+| access_key_id | An AWS Access Key ID | **REQUIRED** |
+| secret_access_key | An AWS Secret Access Key | **REQUIRED** |
+| deploy | Whether to push the image to ECR after building it | `"true"` |
+| github_ssh_key | An SSH Private Key with access to any private repos you need | `""` |
+| healthcheck | A healthcheck path, like /healthcheck | `/healthcheck` |
+| port | The port the server listens on | `3000` |
 
 ## Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
         # Healthcheck the built container
         docker run -d \
         -p ${{inputs.port}}:${{inputs.port}} -e "PORT=${{inputs.port}}" \
-        -e "HEALTHCHECK=${{inputs.healthcheck}} \
+        -e "HEALTHCHECK=${{inputs.healthcheck}}" \
         --name test-container $CONTAINER_IMAGE_SHA
 
         ATTEMPT_COUNT=1

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: "A SSH Private Key with access to any private repos you need"
     required: false
     default: ""
+  healthcheck:
+    description: "A healthcheck path, like /healthcheck",
+    required: false
+    default: "/healthcheck"
+  port:
+    description: "The port the server listens on"
+    required: false
+    default: 3000
 runs:
   using: "composite"
   steps:
@@ -42,6 +50,33 @@ runs:
           $ARG_GITHUB_SSH_KEY \
           $ARG_GITHUB_SHA \
           . 
+
+        # Healthcheck the built container
+        docker run -d \
+        -p ${{inputs.port}}:${{inputs.port}} -e "PORT=${{inputs.port}}" \
+        -e "HEALTHCHECK=${{inputs.healthcheck}} \
+        --name test-container $CONTAINER_IMAGE_SHA
+
+        ATTEMPT_COUNT=1
+        MAX_ATTEMPTS=5
+
+        HEALTHCHECK="http://localhost:${{inputs.port}}${{inputs.healthcheck}}"
+
+        echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
+        until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
+          if [ ${ATTEMPT_COUNT} -eq ${MAX_ATTEMPTS} ];then
+            echo "Container did not pass healthcheck"
+            echo $(docker stop test-container) stopped.
+            exit 1
+          fi
+
+          ATTEMPT_COUNT=$(($ATTEMPT_COUNT+1))
+          sleep 5
+          echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
+        done
+
+        echo "Healthcheck passed!"
+        docker stop test-container
 
         [ "${{inputs.deploy}}" = "true" ] \
           && docker push $CONTAINER_IMAGE_SHA \

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
         done
 
         echo "Healthcheck passed!"
-        docker stop test-container
+        echo $(docker stop test-container) stopped.
 
         [ "${{inputs.deploy}}" = "true" ] \
           && docker push $CONTAINER_IMAGE_SHA \

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "An AWS Secret Access Key"
     required: true
   github_ssh_key:
-    description: "A SSH Private Key with access to any private repos you need"
+    description: "An SSH Private Key with access to any private repos you need"
     required: false
     default: ""
   healthcheck:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   port:
     description: "The port the server listens on"
     required: false
-    default: 3000
+    default: "3000"
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
 
         echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
         until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
-          if [ "$((ATTEMPT_COUNT++))" -gt "${MAX_ATTEMPTS}" ];then
+          if [ "$((++ATTEMPT_COUNT))" -gt "${MAX_ATTEMPTS}" ];then
             echo "Container did not pass healthcheck"
             echo $(docker stop test-container) stopped.
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
 
         HEALTHCHECK="http://localhost:${{inputs.port}}${{inputs.healthcheck}}"
 
-        echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
+        echo "Testing healthcheck ${HEALTHCHECK} : Attempt 1 of ${MAX_ATTEMPTS}"
         until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
           if [ "$((++ATTEMPT_COUNT))" -gt "${MAX_ATTEMPTS}" ];then
             echo "Container did not pass healthcheck"

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,13 @@ inputs:
     required: false
     default: ""
   healthcheck:
-    description: "A healthcheck path, like /healthcheck",
+    description: "A healthcheck path, like /healthcheck"
     required: false
     default: "/healthcheck"
   port:
     description: "The port the server listens on"
     required: false
-    default: "3000"
+    default: 3000
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -57,20 +57,19 @@ runs:
         -e "HEALTHCHECK=${{inputs.healthcheck}}" \
         --name test-container $CONTAINER_IMAGE_SHA
 
-        ATTEMPT_COUNT=1
+        ATTEMPT_COUNT=0
         MAX_ATTEMPTS=5
 
         HEALTHCHECK="http://localhost:${{inputs.port}}${{inputs.healthcheck}}"
 
         echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
         until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
-          if [ ${ATTEMPT_COUNT} -eq ${MAX_ATTEMPTS} ];then
+          if [ "$((ATTEMPT_COUNT++))" -gt "${MAX_ATTEMPTS}" ];then
             echo "Container did not pass healthcheck"
             echo $(docker stop test-container) stopped.
             exit 1
           fi
 
-          ATTEMPT_COUNT=$(($ATTEMPT_COUNT+1))
           sleep 5
           echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
         done

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,6 @@ runs:
 
         HEALTHCHECK="http://localhost:${{inputs.port}}${{inputs.healthcheck}}"
 
-        echo "Testing healthcheck ${HEALTHCHECK} : Attempt 1 of ${MAX_ATTEMPTS}"
         until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
           if [ "$((++ATTEMPT_COUNT))" -gt "${MAX_ATTEMPTS}" ];then
             echo "Container did not pass healthcheck"
@@ -71,7 +70,7 @@ runs:
           fi
 
           sleep 5
-          echo "Testing healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
+          echo "Tested healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
         done
 
         echo "Healthcheck passed!"


### PR DESCRIPTION
resolves glg/metadevops-issues#511

This adds logic to this action to run the container and test its healthcheck prior to pushing the container up to ECR. The action accepts new optional inputs, `healthcheck` and `port`, with sensible defaults.

See it working: https://github.com/glg/echo/runs/1443393959