### PR TITLE
Allow users to pass environment variables to `docker run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ This action requires certain things to be configured in your repo:
 
 ### Config Notes
 
-* `env_file` - The [docker
-  format](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file) for this file is `NAME=value`.
+* `env_file` - The format for this file is `NAME=value` as described in the [docker docs](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
   Notice the lack of the `export` keyword.
 
 ## Example Usage

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ This action requires certain things to be configured in your repo:
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |
 | access_key_id | An AWS Access Key ID | **REQUIRED** |
-| secret_access_key | An AWS Secret Access Key | **REQUIRED** |
 | deploy | Whether to push the image to ECR after building it | `"true"` |
+| dockerfile | Custom Dockerfile path to use to build your image (`prod.Dockerfile`) | `Dockerfile` |
+| ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |
+| env_file | File containing environment variables required for app to run and pass healthcheck | `""` |
 | github_ssh_key | An SSH Private Key with access to any private repos you need | `""` |
 | healthcheck | A healthcheck path, like /healthcheck | `/healthcheck` |
 | port | The port the server listens on | `3000` |
+| secret_access_key | An AWS Secret Access Key | **REQUIRED** |
+
+### Config Notes
+
+* `env_file` - The [docker
+  format](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file) for this file is `NAME=value`.
+  Notice the lack of the `export` keyword.
 
 ## Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,8 @@ runs:
         # If they are specified, we pass them along in the docker run commmand
         ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml)
         if [ -n "$ENV_VARIABLES" ]; then
-          ENV_VARIABLES="-e $VARIABLES"
+          ENV_VARIABLES="-e $ENV_VARIABLES"
         fi
-
 
         eval docker build \
           -t $CONTAINER_IMAGE_SHA \

--- a/action.yml
+++ b/action.yml
@@ -91,8 +91,9 @@ runs:
           until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
             if [ "$((++ATTEMPT_COUNT))" -gt "${MAX_ATTEMPTS}" ];then
               echo "::error::Container did not pass healthcheck at $HEALTHCHECK after $MAX_ATTEMPTS attampts"
-              echo "docker run output:"
+              echo "::group::docker logs"
               docker logs test-container
+              echo "::endgroup::"
               echo $(docker stop test-container) stopped.
               exit 1
             fi

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,15 @@ runs:
           ENV_VARIABLES="-e $ENV_VARIABLES"
         fi
 
+          echo ::info::docker build \
+          -t $CONTAINER_IMAGE_SHA \
+          -t $CONTAINER_IMAGE_LATEST \
+          $CUSTOM_DOCKERFILE \
+          $ARG_GITHUB_SSH_KEY \
+          $ARG_GITHUB_SHA \
+          $ENV_VARIABLES \
+          .
+
         eval docker build \
           -t $CONTAINER_IMAGE_SHA \
           -t $CONTAINER_IMAGE_LATEST \

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
   env_file:
     default: ""
-    description: File containing environment variables required for app to pass healthcheck
+    description: File containing environment variables required for app to run and pass healthcheck
     required: false
   access_key_id:
     description: "An AWS Access Key ID"

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,14 @@ runs:
           CUSTOM_DOCKERFILE="-f ${{ inputs.dockerfile }}"
         fi
 
+        eval docker build \
+          -t $CONTAINER_IMAGE_SHA \
+          -t $CONTAINER_IMAGE_LATEST \
+          $CUSTOM_DOCKERFILE \
+          $ARG_GITHUB_SSH_KEY \
+          $ARG_GITHUB_SHA \
+          .
+
         # read environment variables from workflow YAML
         # If they are specified, we pass them along in the docker run commmand
         ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml)
@@ -66,28 +74,11 @@ runs:
           ENV_VARIABLES="-e $ENV_VARIABLES"
         fi
 
-          echo ::info::docker build \
-          -t $CONTAINER_IMAGE_SHA \
-          -t $CONTAINER_IMAGE_LATEST \
-          $CUSTOM_DOCKERFILE \
-          $ARG_GITHUB_SSH_KEY \
-          $ARG_GITHUB_SHA \
-          $ENV_VARIABLES \
-          .
-
-        eval docker build \
-          -t $CONTAINER_IMAGE_SHA \
-          -t $CONTAINER_IMAGE_LATEST \
-          $CUSTOM_DOCKERFILE \
-          $ARG_GITHUB_SSH_KEY \
-          $ARG_GITHUB_SHA \
-          $ENV_VARIABLES \
-          .
-
         if [ -n "${{inputs.healthcheck}}" ]; then
           # Healthcheck the built container
           docker run -d \
             -p ${{inputs.port}}:${{inputs.port}} \
+            $ENV_VARIABLES \
             -e "HEALTHCHECK=${{inputs.healthcheck}}" \
             -e "PORT=${{inputs.port}}" \
             --name test-container $CONTAINER_IMAGE_SHA

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
 
         # read environment variables from workflow YAML
         # If they are specified, we pass them along in the docker run commmand
-        ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml)
+        ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml 2> /dev/null || true)
         if [ -n "$ENV_VARIABLES" ]; then
           ENV_VARIABLES="-e $ENV_VARIABLES"
         fi

--- a/action.yml
+++ b/action.yml
@@ -73,12 +73,7 @@ runs:
             -p ${{inputs.port}}:${{inputs.port}} \
             -e "HEALTHCHECK=${{inputs.healthcheck}}" \
             -e "PORT=${{inputs.port}}" \
-            --name test-container $CONTAINER_IMAGE_SHA 2>&1 > test-container-output || {
-              code=$?
-              echo "::error::Container failed to `docker run` with exit code $code"
-              cat test-container-output
-              echo 3
-              }
+            --name test-container $CONTAINER_IMAGE_SHA
 
           ATTEMPT_COUNT=0
           MAX_ATTEMPTS=5
@@ -94,6 +89,8 @@ runs:
 
             sleep 5
             echo "Tested healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
+            echo "`docker run` output:"
+            docker logs test-container
           done
 
           echo "Healthcheck passed!"

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,12 @@ runs:
             -p ${{inputs.port}}:${{inputs.port}} \
             -e "HEALTHCHECK=${{inputs.healthcheck}}" \
             -e "PORT=${{inputs.port}}" \
-            --name test-container $CONTAINER_IMAGE_SHA
+            --name test-container $CONTAINER_IMAGE_SHA 2>&1 > test-container-output || {
+              code=$?
+              echo "::error::Container failed to `docker run` with exit code $code"
+              cat test-container-output
+              echo 3
+              }
 
           ATTEMPT_COUNT=0
           MAX_ATTEMPTS=5

--- a/action.yml
+++ b/action.yml
@@ -91,14 +91,14 @@ runs:
           until $(curl --output /dev/null --silent --head --fail --max-time 5 "${HEALTHCHECK}"); do
             if [ "$((++ATTEMPT_COUNT))" -gt "${MAX_ATTEMPTS}" ];then
               echo "::error::Container did not pass healthcheck at $HEALTHCHECK after $MAX_ATTEMPTS attampts"
+              echo "docker run output:"
+              docker logs test-container
               echo $(docker stop test-container) stopped.
               exit 1
             fi
 
             sleep 5
             echo "Tested healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
-            echo "docker run output:"
-            docker logs test-container
           done
 
           echo "Healthcheck passed!"

--- a/action.yml
+++ b/action.yml
@@ -59,12 +59,21 @@ runs:
           CUSTOM_DOCKERFILE="-f ${{ inputs.dockerfile }}"
         fi
 
+        # read environment variables from workflow YAML
+        # If they are specified, we pass them along in the docker run commmand
+        ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml)
+        if [ -n "$ENV_VARIABLES" ]; then
+          ENV_VARIABLES="-e $VARIABLES"
+        fi
+
+
         eval docker build \
           -t $CONTAINER_IMAGE_SHA \
           -t $CONTAINER_IMAGE_LATEST \
           $CUSTOM_DOCKERFILE \
           $ARG_GITHUB_SSH_KEY \
           $ARG_GITHUB_SHA \
+          $ENV_VARIABLES \
           .
 
         if [ -n "${{inputs.healthcheck}}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
 
             sleep 5
             echo "Tested healthcheck ${HEALTHCHECK} : Attempt ${ATTEMPT_COUNT} of ${MAX_ATTEMPTS}"
-            echo "`docker run` output:"
+            echo "docker run output:"
             docker logs test-container
           done
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   ecr_uri:
     description: "The URI for the ECR repository"
     required: true
+  env_file:
+    default: ""
+    description: File containing environment variables required for app to pass healthcheck
+    required: false
   access_key_id:
     description: "An AWS Access Key ID"
     required: true
@@ -67,18 +71,15 @@ runs:
           $ARG_GITHUB_SHA \
           .
 
-        # read environment variables from workflow YAML
-        # If they are specified, we pass them along in the docker run commmand
-        ENV_VARIABLES=$(python -c 'import yaml,sys;result=yaml.safe_load(sys.stdin);print(" -e ".join(result["jobs"]["build-and-deploy"]["steps"].pop()["env"].keys()))' < .github/workflows/build-and-push-to-ecr.yml 2> /dev/null || true)
-        if [ -n "$ENV_VARIABLES" ]; then
-          ENV_VARIABLES="-e $ENV_VARIABLES"
+        if [ -n "${{ inputs.env_file }}" ]; then
+          ENV_FILE="--env-file ${{ inputs.env_file }}"
         fi
 
         if [ -n "${{inputs.healthcheck}}" ]; then
           # Healthcheck the built container
           docker run -d \
             -p ${{inputs.port}}:${{inputs.port}} \
-            $ENV_VARIABLES \
+            $ENV_FILE \
             -e "HEALTHCHECK=${{inputs.healthcheck}}" \
             -e "PORT=${{inputs.port}}" \
             --name test-container $CONTAINER_IMAGE_SHA


### PR DESCRIPTION
1. If any `env:` variables are [specified in the command](https://github.com/glg/cm-data-linkedin-profile-harvest/blob/gds/.github/workflows/build-and-push-to-ecr.yml#L24-L31), those values are passed down to the `docker run` command.
2. If the healthcheck fails. This will print the output of `docker logs test-container` which can sometimes be [useful](https://github.com/glg/cm-data-linkedin-profile-harvest/runs/1711118800?check_suite_focus=true#step:3:178). It's not obvious that these are available to view though (UX).

I ran a file with no `env:` specified to make sure it didn't break anything. https://github.com/glg/psf-microsite/actions/runs/489079686


## Problems/gotchas

The current solution is a bit rigid.

1. It currently relies on the name of the job to be `build-and-deploy`. 

    ## Fix - Relatively easy to mitigate 
    
    Find all the jobs and take the first one.
1. It assumes the last step is the step to search for environment variables. 
    
    ## Fix - Relatively easy to mitigate
    
    Could look harder and pull in variables from every step.