### PR TITLE
added optional build_config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This action requires certain things to be configured in your repo:
 | Input | Description | Default |
 |-------|-------------|---------|
 | access_key_id | An AWS Access Key ID | **REQUIRED** |
+| build_config | Config file used during `docker build` (example `webpack.config.js`) to install your app | **REQUIRED** |
 | deploy | Whether to push the image to ECR after building it | `"true"` |
 | dockerfile | Custom Dockerfile path to use to build your image (`prod.Dockerfile`) | `Dockerfile` |
 | ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action requires certain things to be configured in your repo:
 | Input | Description | Default |
 |-------|-------------|---------|
 | access_key_id | An AWS Access Key ID | **REQUIRED** |
-| build_config | Config file used during `docker build` (example `webpack.config.js`) to install your app | **REQUIRED** |
+| build_config | Config file used during `docker build` usually `postinstall` (example `webpack.config.js`) to install your app (**DO NOT BUILD YOUR APP IN `npm install`**)| `""` |
 | deploy | Whether to push the image to ECR after building it | `"true"` |
 | dockerfile | Custom Dockerfile path to use to build your image (`prod.Dockerfile`) | `Dockerfile` |
 | ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action requires certain things to be configured in your repo:
 | Input | Description | Default |
 |-------|-------------|---------|
 | access_key_id | An AWS Access Key ID | **REQUIRED** |
-| build_config | Config file used during `docker build` usually `postinstall` (example `webpack.config.js`) to install your app (**DO NOT BUILD YOUR APP IN `npm install`**)| `""` |
+| build_config | Config file used during `docker build` usually `postinstall` (example `webpack.config.js`) to install your app. Do not build your app in `npm install`. | `""` |
 | deploy | Whether to push the image to ECR after building it | `"true"` |
 | dockerfile | Custom Dockerfile path to use to build your image (`prod.Dockerfile`) | `Dockerfile` |
 | ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: "Build and Deploy to ECR"
 description: "Builds an image from a dockerfile, and pushes it up to ECR"
 inputs:
+  build_config:
+    description: File used during build (usually in postinstall) to install your app
+    required: false
+    default: ""
   deploy:
     description: "Whether to push the image to ECR after building it"
     required: false
@@ -63,10 +67,15 @@ runs:
           CUSTOM_DOCKERFILE="-f ${{ inputs.dockerfile }}"
         fi
 
+        if [ -n "${{ inputs.build_config }}" ]; then
+          ARG_BUILD_CONFIG='--build-arg "BUILD_CONFIG=${{ inputs.build_config }}"'
+        fi
+
         eval docker build \
           -t $CONTAINER_IMAGE_SHA \
           -t $CONTAINER_IMAGE_LATEST \
           $CUSTOM_DOCKERFILE \
+          $ARG_BUILD_CONFIG \
           $ARG_GITHUB_SSH_KEY \
           $ARG_GITHUB_SHA \
           .


### PR DESCRIPTION
Allows users to set a `build_config` (was originally named `build_file`) that is used during `docker build` to install the app.

This file is usually referenced in `postinstall` I wasn't use how to call that out (read: slyly hint that you shouldn't be building during `install`).

This file is usually `Gruntfile.js` or `webpack.config.js` is most cases. This needs to be accompanied by changes in the CLI that dump out `Dockerfile` images that respect this (`ARG BUILD_CONFIG`).

The changes to the Dockerfile are:

```Dockerfile
# weird but makes this noop by default
# Tried the empty string, but that didn't work as expected. 
# It ended up copying everything in the directory
ARG BUILD_CONFIG=package*.json

...

COPY package*.json $BUILD_CONFIG ./
```