### PR TITLE
Add a an input to facilitate crossbuilding and mutli-arch images

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,26 @@ jobs:
         secret_access_key: ${{secrets.ECR_AWS_SECRET_ACCESS_KEY}}
         github_ssh_key: ${{secrets.GITHUB_SSH_KEY}}
 ```
+
+## Example building arm64 images
+```yml
+name: Build Image and Push to ECR
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@master
+    - uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      with:
+        platforms: linux/arm64
+    - uses: docker/setup-buildx-action@0d135e0c2fc0dba0729c1a47ecfcf5a3c7f8579e
+      with:
+        install: true
+        version: latest
+    - uses: glg-public/build-and-deploy-ecr@main
+      with:
+        ecr_uri: ${{secrets.ECR_URI}}
+        access_key_id: ${{secrets.AWS_ACCESS_KEY_ID}}
+        secret_access_key: ${{secrets.ECR_AWS_SECRET_ACCESS_KEY}}
+```

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,7 @@ runs:
 
         if [ -n "${{ inputs.image_platform }}" ]; then
           IMAGE_PLATFORM="--platform ${{ inputs.image_platform }}"
+          echo "::info::using platform ${{ inputs.image_platform }}."
         fi
 
         if [ -n "${{ inputs.build_config }}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -77,8 +77,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.image_platform }}" ]; then
-          IMAGE_PLATFORM="--platform ${{ inputs.image_platform }}"
-          echo "::info::using platform ${{ inputs.image_platform }}."
+          IMAGE_PLATFORM="--platform ${{ inputs.image_platform }} --load"
         fi
 
         if [ -n "${{ inputs.build_config }}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.image_platform }}" ]; then
-          IMAGE_PLATFORM="--platform ${{ inpluts.image_platform }}"
+          IMAGE_PLATFORM="--platform ${{ inputs.image_platform }}"
         fi
 
         if [ -n "${{ inputs.build_config }}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Custom Dockerfile name
     required: false
     default: Dockerfile
+  image_platform:
+    description: Platforms to build the image to run on
+    required: false
+    default: ""
   ecr_uri:
     description: "The URI for the ECR repository"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,10 @@ runs:
           CUSTOM_DOCKERFILE="-f ${{ inputs.dockerfile }}"
         fi
 
+        if [ -n "${{ inputs.image_platform }}" ]; then
+          IMAGE_PLATFORM="--platform ${{ inpluts.image_platform }}"
+        fi
+
         if [ -n "${{ inputs.build_config }}" ]; then
           ARG_BUILD_CONFIG='--build-arg "BUILD_CONFIG=${{ inputs.build_config }}"'
         fi
@@ -79,6 +83,7 @@ runs:
         eval docker build \
           -t $CONTAINER_IMAGE_SHA \
           -t $CONTAINER_IMAGE_LATEST \
+          $IMAGE_PLATFORM \
           $CUSTOM_DOCKERFILE \
           $ARG_BUILD_CONFIG \
           $ARG_GITHUB_SSH_KEY \


### PR DESCRIPTION
This adds an `image_platform` option that defaults to emply string.  If the option is specified it builds some command line options to pass to `docker build`.  Note that this assumes that the user has setup docker buildx in an earlier action and aliased it to docker build.  