### PR TITLE
Added support for buildkit ssh functionality

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,10 +122,20 @@ runs:
 
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
-          ssh-agent -a $SSH_AUTH_SOCK
-          base64 --decode <<< "${{ inputs.github_ssh_key }}" | ssh-add -
+          # if dockerfile requests buildkit functionality, appease it
+          # otherwise default to the build argument
+          if grep --quiet 'mount=type=ssh' './${{ inputs.dockerfile }}'; then
+            ssh-agent -a $SSH_AUTH_SOCK
+            base64 --decode <<< "${{ inputs.github_ssh_key }}" | ssh-add -
 
-          echo ARG_GITHUB_SSH_KEY="--ssh default=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+            echo '::set-output name=docker-buildkit::1'
+            echo ARG_GITHUB_SSH_KEY="--ssh default=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+          else
+            # Special handling for multiline environment veriables
+            # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-6
+            echo 'ARG_GITHUB_SSH_KEY<<EOF' >> $GITHUB_ENV
+            echo '--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)
@@ -183,7 +193,7 @@ runs:
     - name: Docker build
       shell: bash
       env:
-        DOCKER_BUILDKIT: 1
+        DOCKER_BUILDKIT: ${{ steps.setup.outputs.docker-buildkit }}
       run: >
         docker build
         --tag $CONTAINER_IMAGE_SHA

--- a/action.yml
+++ b/action.yml
@@ -131,11 +131,7 @@ runs:
             echo '::set-output name=docker-buildkit::1'
             echo ARG_GITHUB_SSH_KEY="--ssh default=$SSH_AUTH_SOCK" >> $GITHUB_ENV
           else
-            # Special handling for multiline environment veriables
-            # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-6
-            echo 'ARG_GITHUB_SSH_KEY<<EOF' >> $GITHUB_ENV
-            echo '--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
-            echo 'EOF' >> $GITHUB_ENV
+            echo ARG_GITHUB_SSH_KEY='--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
           fi
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
           ssh-agent -a $SSH_AUTH_SOCK
-          ssh-add - <(base64 --decode <<< "${{ inputs.github_ssh_key }}")
+          base64 --decode <<< "${{ inputs.github_ssh_key }}" | ssh-add -
 
           echo ARG_GITHUB_SSH_KEY="--ssh default=$SSH_AUTH_SOCK" >> $GITHUB_ENV
         fi

--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,8 @@ runs:
 
     - name: Docker build
       shell: bash
+      env:
+        DOCKER_BUILDKIT: 1
       run: >
         docker build
         --tag $CONTAINER_IMAGE_SHA

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,7 @@ runs:
             echo 'ARG_GITHUB_SSH_KEY<<EOF' >> $GITHUB_ENV
             echo '--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
             echo 'EOF' >> $GITHUB_ENV
+          fi
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)

--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,8 @@ runs:
     - name: Setup environment variables
       id: setup
       shell: bash
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         branch=$(cut --fields 3 --delimiter '/' <<< '${{ github.ref }}')
         container_base=$(tr '[:upper:]' '[:lower:]' <<< "${{ inputs.ecr_uri }}/github/${{ github.repository }}/$branch")
@@ -120,11 +122,10 @@ runs:
 
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
-          # Special handling for multiline environment veriables
-          # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-6
-          echo 'ARG_GITHUB_SSH_KEY<<EOF' >> $GITHUB_ENV
-          echo '--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          ssh-agent -a $SSH_AUTH_SOCK
+          ssh-add - <(base64 --decode <<< "${{ inputs.github_ssh_key }}")
+
+          echo ARG_GITHUB_SSH_KEY="--ssh default=$SSH_AUTH_SOCK" >> $GITHUB_ENV
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)


### PR DESCRIPTION
It looks at the contents of the `Dockerfile` to decide how to inject the SSH key into the environment and which SSH param to use during the build process.