### PR TITLE
Removed quotes from around GITHUB_SSH_KEY

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -187,12 +187,6 @@ runs:
         --password '${{ steps.get-login-password.outputs.password }}'
         ${{ inputs.ecr_uri }}
 
-    - name: debug
-      shell: bash
-      run: |
-        echo "::debug::\$SHELL=$SHELL"
-        echo "::debug::lines of GITHUB_SSH_KEY=$(echo "$GITHUB_SSH_KEY" | wc -l)"
-        echo "::debug::lines of ARG_GITHUB_SSH_KEY=$(echo "$ARG_GITHUB_SSH_KEY" | wc -l)"
     - name: Docker build
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -120,11 +120,7 @@ runs:
 
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
-          # Special handling for multiline environment veriables
-          # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-6
-          echo 'ARG_GITHUB_SSH_KEY<<EOF' >> $GITHUB_ENV
-          echo '--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          echo ARG_GITHUB_SSH_KEY='--build-arg "GITHUB_SSH_KEY=${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,12 @@ runs:
         --password '${{ steps.get-login-password.outputs.password }}'
         ${{ inputs.ecr_uri }}
 
+    - name: debug
+      shell: bash
+      run: |
+        echo $SHELL
+        echo "$GITHUB_SSH_KEY" | wc -l
+        echo "$ARG_GITHUB_SSH_KEY" | wc -l
     - name: Docker build
       shell: bash
       run: >

--- a/action.yml
+++ b/action.yml
@@ -178,9 +178,9 @@ runs:
     - name: debug
       shell: bash
       run: |
-        echo $SHELL
-        echo "$GITHUB_SSH_KEY" | wc -l
-        echo "$ARG_GITHUB_SSH_KEY" | wc -l
+        echo "::debug::\$SHELL=$SHELL"
+        echo "::debug::lines of GITHUB_SSH_KEY=$(echo "$GITHUB_SSH_KEY" | wc -l)"
+        echo "::debug::lines of ARG_GITHUB_SSH_KEY=$(echo "$ARG_GITHUB_SSH_KEY" | wc -l)"
     - name: Docker build
       shell: bash
       run: >

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
 
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
-          echo ARG_GITHUB_SSH_KEY='--build-arg "GITHUB_SSH_KEY=${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
+          echo ARG_GITHUB_SSH_KEY='--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
 
         # Only include the GITHUB_SSH_KEY if it exists
         if [ -n '${{ inputs.github_ssh_key }}' ]; then
-          echo ARG_GITHUB_SSH_KEY='--build-arg GITHUB_SSH_KEY="${{ inputs.github_ssh_key }}"' >> $GITHUB_ENV
+          echo ARG_GITHUB_SSH_KEY='--build-arg GITHUB_SSH_KEY=${{ inputs.github_ssh_key }}' >> $GITHUB_ENV
         fi
 
         # Only include the GITHUB_SHA if it is used (supresses a warning)


### PR DESCRIPTION
They were getting passed to `base64` which was causing the decode to fail. I'm not sure how this only failed some of the time.