### PR TITLE
log stderr during healthcheck failures

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -169,11 +169,10 @@ async function runHealthcheck(imageName, inputs) {
       "If your container does not require a healthcheck (most jobs don't), then set healthcheck to a blank string."
     );
     core.startGroup("docker logs");
-    const { stdout: dockerLogsStdout } = await util.execFile("docker", [
-      "logs",
-      "test-container",
-    ]);
+    const { stdout: dockerLogsStdout, stderr: dockerLogsStderr } =
+      await util.execFile("docker", ["logs", "test-container"]);
     console.log(dockerLogsStdout);
+    console.log(dockerLogsStderr);
     core.endGroup();
     process.exit(1);
   }


### PR DESCRIPTION
re: https://docs.docker.com/config/containers/logging/

`docker logs` outputs both stdout and stderr from the container, on their respective channels. Recently had an issue where it was failing, but stderr wasn't getting logged. made debugging harder than it needed to be.

resolves #31 