### PR TITLE
Fix RUN --mount=type=ssh

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -401,6 +401,7 @@ async function main() {
   const sshAuthSock = "/tmp/ssh_agent.sock";
 
   // Only include the GITHUB_SSH_KEY if it exists
+  core.startGroup("docker ssh setup");
   if (inputs.githubSSHKey) {
     /**
      * If the dockerfile requests buildkit functionality,
@@ -411,7 +412,7 @@ async function main() {
       const key = Buffer.from(inputs.githubSSHKey, "base64").toString("utf8");
       const keyFileName = "key";
       await fs.writeFile(keyFileName, key);
-      await util.execFile("ssh-add", [keyFileName]);
+      await util.execFile("ssh-add", [keyFileName], { env: { "SSH_AUTH_SOCK": sshAuthSock }});
       dockerBuildArgs.push(
         "--ssh",
         "default"
@@ -423,6 +424,7 @@ async function main() {
       );
     }
   }
+  core.endGroup();
 
   // Only include the GITHUB_SHA if it is used
   if (/GITHUB_SHA/.test(dockerfile)) {

--- a/lib.js
+++ b/lib.js
@@ -451,6 +451,9 @@ async function main() {
     buildEnv["DOCKER_BUILDKIT"] = 1;
     buildEnv["BUILDKIT_PROGRESS"] = "plain";
   }
+  if (/mount=type=ssh/m.test(dockerfile)) {
+    buildEnv["SSH_AUTH_SOCK"] = sshAuthSock;
+  }
   console.log(buildEnv);
   core.endGroup();
 

--- a/lib.js
+++ b/lib.js
@@ -412,6 +412,7 @@ async function main() {
       const key = Buffer.from(inputs.githubSSHKey, "base64").toString("utf8");
       const keyFileName = "key";
       await fs.writeFile(keyFileName, key);
+      await fs.chmod(keyFileName, "0644");
       await util.execFile("ssh-add", [keyFileName], { env: { "SSH_AUTH_SOCK": sshAuthSock }});
       dockerBuildArgs.push(
         "--ssh",

--- a/lib.js
+++ b/lib.js
@@ -412,7 +412,7 @@ async function main() {
       const key = Buffer.from(inputs.githubSSHKey, "base64").toString("utf8");
       const keyFileName = "key";
       await fs.writeFile(keyFileName, key);
-      await fs.chmod(keyFileName, "0644");
+      await fs.chmod(keyFileName, "0600");
       await util.execFile("ssh-add", [keyFileName], { env: { "SSH_AUTH_SOCK": sshAuthSock }});
       dockerBuildArgs.push(
         "--ssh",

--- a/test/main.js
+++ b/test/main.js
@@ -139,10 +139,12 @@ describe("Main Workflow", () => {
       ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
     };
     inputStub.returns(inputs);
+    const chmodStub = sandbox.stub(fs, "chmod").resolves();
 
     await lib.main();
 
     expect(writeFileStub.firstCall.args[1]).to.equal("abcdefgh");
+    expect(chmodStub.firstCall.args[1]).to.equal("0600");
 
     const buildArgs = buildStub.getCall(0).args[0];
     expect(
@@ -265,6 +267,7 @@ describe("Main Workflow", () => {
     expect(buildEnv).to.deep.equal({
       DOCKER_BUILDKIT: 1,
       BUILDKIT_PROGRESS: "plain",
+      SSH_AUTH_SOCK: "/tmp/ssh_agent.sock"
     });
   });
 


### PR DESCRIPTION
The ssh-agent works by knowing the location of its socket by using the environment variable `SSH_AUTH_SOCK` and a consequence of the docker build --ssh integration, this also needs to be in the environment passed to docker build.

This was tested here: https://github.com/glg/lead-intake/actions/runs/1775128056