### PR TITLE
Add the ability to execute unit tests during docker build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,16 @@ inputs:
     required: true
   env_file:
     default: ""
-    description: File containing environment variables required for app to run and pass healthcheck
+    description: File containing environment variables required for app to run and pass healthcheck or unit tests
     required: false
   github_ssh_key:
     description: SSH Private Key with access to any private repos you need
     required: false
     default: ""
+  unit_test:
+    description: Command to run in order to execute unit tests. Failing tests will prevent deployment.
+    required: false
+    default: ''
   healthcheck:
     description: healthcheck path, like /healthcheck
     required: false

--- a/lib.js
+++ b/lib.js
@@ -169,7 +169,7 @@ async function runUnitTest(imageName, inputs) {
   const { stdout: dockerRunStdout, stderr: dockerRunStderr } = await util.execFile("docker", [
     ...args,
     imageName,
-    inputs.unitTest
+    ...inputs.unitTest.match(/"[^"]+"|'[^']+'|\S+/g)
   ])
   timeoutObj.cancel()
   console.log(dockerRunStdout)

--- a/test/runUnitTests.js
+++ b/test/runUnitTests.js
@@ -1,0 +1,85 @@
+const sinon = require("sinon");
+const lib = require("../lib");
+const core = require("@actions/core");
+const { expect } = require("chai");
+
+const sandbox = sinon.createSandbox();
+
+const imageName = "myimage:latest";
+const defaultInputs = {
+  unitTest: "npm test"
+};
+
+let execStub;
+
+describe("lib.runUnitTest", () => {
+  beforeEach(() => {
+    sandbox.restore();
+    // Comment this out when debugging tests
+    sandbox.stub(console, "log");
+    sandbox.stub(core, "error");
+    sandbox.stub(core, "warning");
+    sandbox.stub(core, "startGroup");
+    sandbox.stub(core, "endGroup");
+
+    execStub = sandbox.stub(lib.util, "execFile").resolves({ stdout: "someoutput" });
+    sandbox.stub(lib.util, "sleep").resolves();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it("executes the provided unit_test command against the docker image", async () => {
+    const inputs = { ...defaultInputs };
+    await lib.runUnitTest(imageName, inputs);
+
+    const dockerRunArgs = execStub.getCall(0).args[1];
+
+    expect(dockerRunArgs.includesInOrder("myimage:latest", "npm test")).to.be.true;
+  });
+
+  it("adds an env file if specified in inputs", async () => {
+    const inputs = {
+      ...defaultInputs,
+      envFile: "unitTest.env"
+    };
+    await lib.runUnitTest(imageName, inputs);
+
+    const dockerRunArgs = execStub.getCall(0).args[1];
+
+    expect(dockerRunArgs.includesInOrder("--env-file", inputs.envFile)).to.be.true;
+  });
+
+  it("resolves successfully when unit tests pass", async () => {
+    const inputs = { ...defaultInputs }
+    return expect(lib.runUnitTest(imageName, inputs)).to.be.fulfilled;
+  });
+
+  it("should timeout successfully after 30 minutes", async () => {
+    const execTimeoutMs = 1000 * 60 * 60 * 31; // 31 minutes
+    const processTimeoutMs = 1000 * 60 * 60 * 30; // 30 minutes 
+    const clock = sandbox.useFakeTimers();
+    
+    // configure stubs
+    execStub
+      .onFirstCall()
+      .resolves(new Promise(resolve => setTimeout(() => resolve({ stdout: "timed out" }), execTimeoutMs)));
+    execStub.onSecondCall().resolves({ stdout: "someoutput" });
+    execStub.onThirdCall().resolves({ stdout: "someoutput" });
+    const exitStub = sandbox.stub(process, "exit");
+
+    // run function
+    lib.runUnitTest(imageName, { ...defaultInputs });
+    
+    // advance the clock to trigger the timeout
+    await clock.tickAsync(processTimeoutMs);
+    
+    // assertions
+    const firstDockerRunArgs = execStub.getCall(1).args[1];
+    const secondDockerRunArgs = execStub.getCall(2).args[1];
+    expect(firstDockerRunArgs.includesInOrder("logs", "test-container")).to.be.true;
+    expect(secondDockerRunArgs.includesInOrder("stop", "test-container")).to.be.true;
+    expect(exitStub.calledWith(1)).to.be.true;
+  });
+});


### PR DESCRIPTION
We have added a new input named `unit_test` that will allow a user to pass the cmd that should be used to execute unit tests within a docker image.

To support this, we have added the lib function `runUnitTest` and supporting unit tests for the new function. 

The idea is that the unit tests will be executed and, if they fail, will block further running or deployment of the docker build process. This should work with or without the deploy flag being set to `true`.

The changes can be demonstrated as working [here](https://github.com/glg/revenue-and-expense-recognition/runs/5246446154?check_suite_focus=true)

co-authored-by: matteozambon89 <mzambon@glgroup.com>