### PR TITLE
Add support for injecting package read token for --mount=type=secret,id=npmrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This action requires certain things to be configured in your repo:
 | ecr_uri | The URI of the ECR repository to push to | **REQUIRED** |
 | env_file | File containing environment variables required for app to run and pass healthcheck | `""` |
 | github_ssh_key | An SSH Private Key with access to any private repos you need | `""` |
+| github_packages_token | A Github token wih read access to the github npm package registry | `""` |
 | healthcheck | A healthcheck path, like /healthcheck | `/healthcheck` |
 | port | The port the server listens on | `3000` |
 | secret_access_key | An AWS Secret Access Key | **REQUIRED** |

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: SSH Private Key with access to any private repos you need
     required: false
     default: ""
+  github_packages_token:
+    description: Github token with permissions to read from the github packages registry
+    required: false
+    default: ""
   healthcheck:
     description: healthcheck path, like /healthcheck
     required: false

--- a/lib.js
+++ b/lib.js
@@ -427,6 +427,19 @@ async function main() {
   }
   core.endGroup();
 
+  // Setup an npmrc to provide access to github's npm registry if the dockerfile
+  // is steup to use it.
+  core.startGroup("docker secrets setup for github npm registry");
+  if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
+    const npmrc = `@glg:registry=https://npm.pkg.github.com\nnpm.pkg.github.com/:_authToken=${github.token}`
+    await fs.writeFile("/tmp/.nmprc", npmrc);
+    dockerBuildArgs.push(
+      "--secret",
+      "id=npmrc,src=/tmp/.npmrc"
+    );
+  }
+  core.endGroup();
+
   // Only include the GITHUB_SHA if it is used
   if (/GITHUB_SHA/.test(dockerfile)) {
     dockerBuildArgs.push("--build-arg", `GITHUB_SHA=${sha}`);

--- a/lib.js
+++ b/lib.js
@@ -43,6 +43,7 @@ function getInputs() {
     dockerfile,
     envFile,
     githubSSHKey,
+    githubPackagesToken,
     healthcheck,
     platform,
     port,
@@ -431,16 +432,18 @@ async function main() {
   // Setup an npmrc to provide access to github's npm registry if the dockerfile
   // is steup to use it.
   core.startGroup("docker secrets setup for github npm registry");
-  if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
-    console.log("npm registry secret requested, injecting");
-    const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`
-    const npmrcFileName = "npmrc"
-    console.log(npmrc);
-    await fs.writeFile(npmrcFileName, npmrc);
-    dockerBuildArgs.push(
-      "--secret",
-      `id=npmrc,src=${npmrcFileName}`
-    );
+  if (inputs.githubPackagesToken) {
+    if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
+      console.log("npm registry secret requested, injecting");
+      const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`
+      const npmrcFileName = "npmrc"
+      console.log(npmrc);
+      await fs.writeFile(npmrcFileName, npmrc);
+      dockerBuildArgs.push(
+        "--secret",
+        `id=npmrc,src=${npmrcFileName}`
+      );
+    }
   }
   core.endGroup();
 

--- a/lib.js
+++ b/lib.js
@@ -437,7 +437,6 @@ async function main() {
       console.log("npm registry secret requested, injecting");
       const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`
       const npmrcFileName = "npmrc"
-      console.log(npmrc);
       await fs.writeFile(npmrcFileName, npmrc);
       dockerBuildArgs.push(
         "--secret",

--- a/lib.js
+++ b/lib.js
@@ -431,11 +431,13 @@ async function main() {
   // is steup to use it.
   core.startGroup("docker secrets setup for github npm registry");
   if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
+    console.log("npm registry secret requested, injecting");
     const npmrc = `@glg:registry=https://npm.pkg.github.com\nnpm.pkg.github.com/:_authToken=${github.token}`
-    await fs.writeFile("/tmp/.nmprc", npmrc);
+    console.log(npmrc);
+    await fs.writeFile(".nmprc", npmrc);
     dockerBuildArgs.push(
       "--secret",
-      "id=npmrc,src=/tmp/.npmrc"
+      "id=npmrc,src=.npmrc"
     );
   }
   core.endGroup();
@@ -468,6 +470,7 @@ async function main() {
     buildEnv["SSH_AUTH_SOCK"] = sshAuthSock;
   }
   console.log(buildEnv);
+  console.log(dockerBuildArgs);
   core.endGroup();
 
   // aws_account_id.dkr.ecr.region.amazonaws.com

--- a/lib.js
+++ b/lib.js
@@ -432,12 +432,13 @@ async function main() {
   core.startGroup("docker secrets setup for github npm registry");
   if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
     console.log("npm registry secret requested, injecting");
-    const npmrc = `@glg:registry=https://npm.pkg.github.com\nnpm.pkg.github.com/:_authToken=${github.token}`
+    const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${github.token}`
+    const npmrcFileName = "npmrc"
     console.log(npmrc);
-    await fs.writeFile(".nmprc", npmrc);
+    await fs.writeFile(npmrcFileName, npmrc);
     dockerBuildArgs.push(
       "--secret",
-      "id=npmrc,src=.npmrc"
+      `id=npmrc,src=${npmrcFileName}`
     );
   }
   core.endGroup();

--- a/lib.js
+++ b/lib.js
@@ -27,6 +27,7 @@ function getInputs() {
   const dockerfile = core.getInput("dockerfile");
   const envFile = core.getInput("env_file");
   const githubSSHKey = core.getInput("github_ssh_key");
+  const githubPackagesToken = core.getInput("github_packages_token");
   const healthcheck = core.getInput("healthcheck");
   const platform = core.getInput("platform");
   const port = core.getInput("port");
@@ -432,7 +433,7 @@ async function main() {
   core.startGroup("docker secrets setup for github npm registry");
   if (/mount=type=secret,id=npmrc/m.test(dockerfile)) {
     console.log("npm registry secret requested, injecting");
-    const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${github.token}`
+    const npmrc = `@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`
     const npmrcFileName = "npmrc"
     console.log(npmrc);
     await fs.writeFile(npmrcFileName, npmrc);

--- a/test/main.js
+++ b/test/main.js
@@ -165,7 +165,7 @@ describe("Main Workflow", () => {
     sandbox.stub(fs, "readFile").resolves("RUN --mount=type=secret,id=npmrc,target=/app/.npmrc <<EOF");
     const inputs = {
       dockerfile: "Dockerfile",
-      // githubSSHKey: Buffer.from("abcdefgh", "utf8").toString("base64"),
+      githubPackagesToken: Buffer.from("abcdefgh", "utf8").toString("base64"),
       ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
     };
     inputStub.returns(inputs);
@@ -173,7 +173,7 @@ describe("Main Workflow", () => {
 
     await lib.main();
 
-    expect(writeFileStub.firstCall.args[1]).to.equal("@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=undefined");
+    expect(writeFileStub.firstCall.args[1]).to.equal(`@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`);
     // expect(chmodStub.firstCall.args[1]).to.equal("0600");
 
     const buildArgs = buildStub.getCall(0).args[0];

--- a/test/main.js
+++ b/test/main.js
@@ -169,12 +169,10 @@ describe("Main Workflow", () => {
       ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
     };
     inputStub.returns(inputs);
-    // const chmodStub = sandbox.stub(fs, "chmod").resolves();
 
     await lib.main();
 
     expect(writeFileStub.firstCall.args[1]).to.equal(`@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=${inputs.githubPackagesToken}`);
-    // expect(chmodStub.firstCall.args[1]).to.equal("0600");
 
     const buildArgs = buildStub.getCall(0).args[0];
     expect(

--- a/test/main.js
+++ b/test/main.js
@@ -162,7 +162,7 @@ describe("Main Workflow", () => {
   });
 
   it("injects an .npmrc if secret mount is requested with id=npmrc", async () => {
-    sandbox.stub(fs, "readFile").resolves("--mount=type=secret,id=npmrc,target=/app/.npmrc");
+    sandbox.stub(fs, "readFile").resolves("RUN --mount=type=secret,id=npmrc,target=/app/.npmrc <<EOF");
     const inputs = {
       dockerfile: "Dockerfile",
       // githubSSHKey: Buffer.from("abcdefgh", "utf8").toString("base64"),
@@ -180,7 +180,7 @@ describe("Main Workflow", () => {
     expect(
       buildArgs.includesInOrder(
         "--secret",
-        "id=npmrc,src=/tmp/.npmrc"
+        "id=npmrc,src=.npmrc"
       )
     ).to.be.true;
   });

--- a/test/main.js
+++ b/test/main.js
@@ -165,7 +165,7 @@ describe("Main Workflow", () => {
     sandbox.stub(fs, "readFile").resolves("RUN --mount=type=secret,id=npmrc,target=/app/.npmrc <<EOF");
     const inputs = {
       dockerfile: "Dockerfile",
-      githubPackagesToken: Buffer.from("abcdefgh", "utf8").toString("base64"),
+      githubPackagesToken: "ghp_ABCDE",
       ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
     };
     inputStub.returns(inputs);

--- a/test/main.js
+++ b/test/main.js
@@ -173,14 +173,14 @@ describe("Main Workflow", () => {
 
     await lib.main();
 
-    expect(writeFileStub.firstCall.args[1]).to.equal("@glg:registry=https://npm.pkg.github.com\nnpm.pkg.github.com/:_authToken=undefined");
+    expect(writeFileStub.firstCall.args[1]).to.equal("@glg:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=undefined");
     // expect(chmodStub.firstCall.args[1]).to.equal("0600");
 
     const buildArgs = buildStub.getCall(0).args[0];
     expect(
       buildArgs.includesInOrder(
         "--secret",
-        "id=npmrc,src=.npmrc"
+        "id=npmrc,src=npmrc"
       )
     ).to.be.true;
   });


### PR DESCRIPTION
This PR introduces a new input `github_packages_token` for a workflow to pass in github token with read access to packages.

If this input is provided **and** the dockerfile has `/--mount=type=secret,id=npmrc` in it, the action will write a `.npmrc` file with the provided token to allow npm access to github's package registry.  The action will then pass `--secret id.npmrc` to the builder to allow the context access to it.

This has a test written and has been validated with a refactored Dockerfile for streamliner contining this:

    RUN --mount=type=ssh,id=default,uid=1000,required --mount=type=secret,id=npmrc,target=/app/.npmrc,uid=1000,required <<EOF
      set -e
      GIT_SSH_COMMAND="ssh -v -T -o StrictHostKeyChecking=no" npm clean-install
    EOF

![image](https://user-images.githubusercontent.com/5762261/160714699-5a3587ce-fa40-4a25-b88f-5f637ae24eee.png)
https://github.com/glg/streamliner/blob/gds-casey/Dockerfile