### PR TITLE
Adds support to mount a secrets file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     description: AWS Secret Access Key
     required: true
   secrets_file:
-    description: Path to an env file to be mounted as a secret
+    description: Path to an env file to be mounted as a secret during the build phase of your container
     required: false
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,9 @@ inputs:
   secret_access_key:
     description: AWS Secret Access Key
     required: true
+  secrets_file:
+    description: Path to an env file to be mounted as a secret
+    required: false
 
 outputs:
   container-path:

--- a/lib.js
+++ b/lib.js
@@ -32,6 +32,7 @@ function getInputs() {
   const platform = core.getInput("platform");
   const port = core.getInput("port");
   const registries = core.getInput("registries");
+  const secretsFile = core.getInput("secrets_file");
   return {
     accessKeyId,
     secretAccessKey,
@@ -442,6 +443,20 @@ async function main() {
         "--secret",
         `id=npmrc,src=${npmrcFileName}`
       );
+    }
+  }
+  core.endGroup();
+
+  core.startGroup("docker secrets setup for secrets file");
+  if (inputs.secrets_file) {
+    if (/mount=type=secret,id=secrets/m.test(dockerfile)) {
+      console.log("injecting secrets file into docker build")
+      dockerBuildArgs.push(
+        "--secret",
+        `id=secrets,src=${inputs.secrets_file}`
+      )
+    } else {
+      console.error("did not detect secrets mount in docker file")
     }
   }
   core.endGroup();

--- a/lib.js
+++ b/lib.js
@@ -453,7 +453,7 @@ async function main() {
 
   core.startGroup("docker secrets setup for secrets file");
   if (inputs.secretsFile) {
-    if (/mount=type=secret,id=secrets/.test(dockerfile)) {
+    if (/mount=type=secret,id=secrets/m.test(dockerfile)) {
       console.log("injecting secrets file into docker build")
       dockerBuildArgs.push(
         "--secret",

--- a/test/main.js
+++ b/test/main.js
@@ -183,6 +183,30 @@ describe("Main Workflow", () => {
     ).to.be.true;
   });
 
+  it("injects a secret mount if requested with secrets file", async () => {
+    sandbox.stub(fs, "readFile").resolves("RUN --mount=type=secret,id=secrets <<EOF");
+
+    const inputs = {
+      dockerfile: "Dockerfile",
+      secrets_file: "secrets.env",
+      githubSSHKey: "abcdefgh",
+      ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
+    };
+
+    inputStub.returns(inputs);
+
+    await lib.main();
+
+    const buildArgs = buildStub.getCall(0).args[0];
+    expect(
+      buildArgs.includesInOrder(
+        "--secret",
+        "id=secrets,src=secrets.env"
+      )
+    ).to.be.true;
+  });
+
+
   it("passes the git sha as a build arg only if used in the dockerfile", async () => {
     const readStub = sandbox.stub(fs, "readFile").resolves("GITHUB_SHA");
     const inputs = {

--- a/test/main.js
+++ b/test/main.js
@@ -188,7 +188,7 @@ describe("Main Workflow", () => {
 
     const inputs = {
       dockerfile: "Dockerfile",
-      secrets_file: "secrets.env",
+      secretsFile: "secrets.env",
       githubSSHKey: "abcdefgh",
       ecrURI: "aws_account_id.dkr.ecr.region.amazonaws.com",
     };


### PR DESCRIPTION
Example actions.yml

```yaml
# vi:syntax=yaml
name: Build Image and Push to ECR
on:
  push:
    # You can set these branches to any that you want to build and push images from
    branches:
      - main

jobs:
  build-and-deploy:
    runs-on: ubuntu-20.04
    steps:
      # Checks out the code from this repo
      - uses: actions/checkout@main

      # creates a secrets file on disk
      - name: create a secrets file for docker
        run: |
          echo export AWS_ACCESS_KEY_ID=${{secrets.S3_AWS_ACCESS_KEY_ID}} > secrets.env
          echo export AWS_SECRET_ACCESS_KEY=${{secrets.S3_AWS_SECRET_ACCESS_KEY}} >> secrets.env

      # Builds a docker image from ./dockerfile, and pushes it to our ECR repository
      - uses: rauhryan/build-and-deploy-ecr@secrets-file
        with:
          ecr_uri: ${{secrets.GLGAPP_ECR_URI}}
          access_key_id: ${{secrets.GLGAPP_ECR_AWS_ACCESS_KEY_ID}}
          secret_access_key: ${{secrets.GLGAPP_ECR_AWS_SECRET_ACCESS_KEY}}
          github_ssh_key: ${{secrets.DEPLOYMENT_SSH_KEY}}
          secrets_file: secrets.env
          healthcheck: "/healthcheck"


```