### PR TITLE
Don't use host networking to healthcheck

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -167,8 +167,6 @@ async function runHealthcheck(imageName, inputs) {
   const args = [
     "run",
     "--detach",
-    "--net",
-    "host",
     "--publish",
     `${inputs.port}:${inputs.port}`,
     "--env",


### PR DESCRIPTION
Using `--net host` obscures runtime errors arising from servers in-container binding to other than any-ip "0.0.0.0" and lets this class of error into production where they succumb to the ECS HealthChecker.

This is tested in the echo repo in the test-action branch

![image](https://user-images.githubusercontent.com/5762261/173632930-c934b442-6a05-40ab-8c08-28b9c392ac08.png)
![image](https://user-images.githubusercontent.com/5762261/173632955-6892cd01-1435-407a-9474-a3ff2456f25c.png)

both of these would pass in the `main` branch of this action.

The failing case binds to ip '127.0.0.1' and the passing case binds to '0.0.0.0'.