### PR TITLE
reference inputs.ecrRepositoryOverride

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -437,7 +437,7 @@ async function main() {
    */
   let ecrRepository;
   if (inputs.ecrRepositoryOverride) {
-    ecrRepository = ecrRepositoryOverride;
+    ecrRepository = inputs.ecrRepositoryOverride;
   } else {
     /**
      * This is the default ecr repository name


### PR DESCRIPTION
Fixes a reference error using the ecr_repository_override feature.